### PR TITLE
Fixed Store App Link

### DIFF
--- a/AppPromo.WP8/RateHelper.cs
+++ b/AppPromo.WP8/RateHelper.cs
@@ -145,7 +145,7 @@ namespace AppPromo
             marketplaceReviewTask.Show(); 
             #endif
             #if WIN_RT
-            await Launcher.LaunchUriAsync(new Uri("ms-windows-store:reviewapp?appid=" + CurrentApp.AppId));
+            await Launcher.LaunchUriAsync(new Uri("ms-windows-store://review/?ProductId=" + CurrentApp.AppId));
             #endif
         }
         #pragma warning restore 1998


### PR DESCRIPTION
Before : Link used to go to the homepage of the store app
Now: Link goes to the review mode of the store for the targeted app

Resources used : [Launch the Windows Store App] https://msdn.microsoft.com/en-us/library/windows/apps/mt228343.aspx
