### PR TITLE
Fix review link

### DIFF
--- a/AppPromo.WP8/RateHelper.cs
+++ b/AppPromo.WP8/RateHelper.cs
@@ -252,7 +252,8 @@ namespace AppPromo
 #if WIN_RT
             try
             {
-                await Launcher.LaunchUriAsync(new Uri("ms-windows-store:reviewapp?appid=" + CurrentApp.AppId));
+                var familyName = Windows.ApplicationModel.Package.Current.Id.FamilyName;
+                await Launcher.LaunchUriAsync(new Uri("ms-windows-store://review/?PFN=" + familyName));
             }
             catch (Exception)
             {


### PR DESCRIPTION
Launches the correct review page for the app.  Previously this button just launched the Store without prompting for a review.
